### PR TITLE
Add build scheduler

### DIFF
--- a/.github/workflows/build-site.yml
+++ b/.github/workflows/build-site.yml
@@ -1,0 +1,16 @@
+name: Build site
+
+on:
+  workflow_dispatch:
+  schedule:
+    # 7am UTC (12am PST) every day
+    - cron: '0 7 * * *'
+
+jobs:
+  compute:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Build
+        run: |
+          curl -X POST -d '{}' ${{ secrets.BUILD_SITE_URL }}


### PR DESCRIPTION
This PR adds a workflow that every day, at midnight, will trigger a netlify page redeploy