### PR TITLE
Add generator script to helper tooltip

### DIFF
--- a/components/HelperTooltip.tsx
+++ b/components/HelperTooltip.tsx
@@ -75,18 +75,36 @@ const TooltipIcon = styled(ColoredIcon)`
 
 const TooltipWrapper = styled.div`
   padding: 12px 12px 12px 18px;
-  max-width: 90vw;
+  max-width: 650px;
+  @media (max-width: ${styles.breakpoint}px) {
+    max-width: 90vw;
+  }
 `;
 
-export const HelperTooltip = ({ script, expected }: Pick<TemplateConfig, 'script' | 'expected'>) => {
+const WithPadding = styled.div`
+  padding-top: 12px;
+`;
+
+export const HelperTooltip = ({
+  script: generatorScript,
+  reproScript,
+  expected,
+}: Pick<TemplateConfig, 'script' | 'expected'> & { reproScript: string }) => {
+  const librariesUsed = Object.keys(expected)
+    .map((key) => key as keyof typeof expected)
+    .map((key) => `${key}: ${expected[key]}`)
+    .join('\n');
+
   const configurationBody = (
     <>
       <div>The following libraries were used in this build.</div>
       <StyledCodeSnippets
-        snippets={[
-          { id: '1', renderTabLabel: () => '', Snippet: () => <Highlight language="json">{JSON.stringify(expected, null, 2)}</Highlight> },
-        ]}
+        snippets={[{ id: '1', renderTabLabel: () => '', Snippet: () => <Highlight language="yaml">{librariesUsed}</Highlight> }]}
         hideCopy
+      ></StyledCodeSnippets>
+      <WithPadding>And the following generator script.</WithPadding>
+      <StyledCodeSnippets
+        snippets={[{ id: '1', renderTabLabel: () => '', Snippet: () => <Highlight language="bash">{generatorScript}</Highlight> }]}
       ></StyledCodeSnippets>
     </>
   );
@@ -101,7 +119,7 @@ export const HelperTooltip = ({ script, expected }: Pick<TemplateConfig, 'script
         .
       </div>
       <StyledCodeSnippets
-        snippets={[{ id: '1', renderTabLabel: () => '', Snippet: () => <Highlight language="bash">{script}</Highlight> }]}
+        snippets={[{ id: '1', renderTabLabel: () => '', Snippet: () => <Highlight language="bash">{reproScript}</Highlight> }]}
       ></StyledCodeSnippets>
     </>
   );

--- a/components/StatusRow.tsx
+++ b/components/StatusRow.tsx
@@ -93,7 +93,7 @@ export const StatusRow = memo(({ results, config, id }: TemplateTests) => {
   const [chartRef, { width }] = useElementSize();
   const [selectedHeartBeat, setSelectedHeartBeat] = useState<TestResult>();
   const [hoveredHeartBeat, setHoveredHeartBeat] = useState<TestResult>();
-  const templateScript = useMemo(() => getReproScript(id), [id]);
+  const reproScript = useMemo(() => getReproScript(id), [id]);
 
   // Not that it will ever happen, but just in case so we don't break the website because of malformed data.
   if (!results?.length) {
@@ -115,7 +115,7 @@ export const StatusRow = memo(({ results, config, id }: TemplateTests) => {
         <ResultHeading>
           <StatusBadge style={{ marginBottom: '2px' }} status={mostRecentStatus}></StatusBadge>
           <TemplateName>{config?.name ?? id}</TemplateName>
-          {config && <HelperTooltip script={templateScript} expected={config?.expected} />}
+          {config && <HelperTooltip script={config?.script} reproScript={reproScript} expected={config?.expected} />}
         </ResultHeading>
         <HeartBeatChart>
           {resultsToDisplay.map((result) => {


### PR DESCRIPTION
Some context was missing, it make sense to show that we are using scripts e.g. `ng new`, `npx create-react-app`, etc.