### PR TITLE
Add version picker to subnav

### DIFF
--- a/client/storybook-versions.ts
+++ b/client/storybook-versions.ts
@@ -1,0 +1,28 @@
+const VERSIONS_ENDPOINT = 'https://storybook.js.org/versions.json';
+
+type StorybookVersion = {
+  version: string;
+  info: {
+    plain: string;
+  };
+};
+
+type StorybookVersionData = {
+  latest: StorybookVersion;
+  next: StorybookVersion;
+};
+
+export type StorybookVersions = {
+  latest: string;
+  next: string;
+};
+
+export const getStorybookVersions = async (): Promise<StorybookVersions> => {
+  const res = await fetch(VERSIONS_ENDPOINT);
+  const data = (await res.json()) as StorybookVersionData;
+
+  return {
+    latest: data.latest.version.split('.').slice(0, -1).join('.'),
+    next: data.next.version.split('.').slice(0, -1).join('.'),
+  };
+};

--- a/components/layout/AppLayout.tsx
+++ b/components/layout/AppLayout.tsx
@@ -6,10 +6,11 @@ import { styled } from '@storybook/theming';
 import NextLink from 'next/link';
 import { Header, HeaderProps } from './Header';
 import { GlobalStyles } from '~/styles/GlobalStyles';
+import { StorybookNpmTag } from '~/model/types';
 
 type FooterProps = React.ComponentProps<typeof MarketingFooter>;
 
-export type PageProps = Partial<HeaderProps> & Pick<FooterProps, 'subscriberCount'>;
+export type PageProps = Partial<HeaderProps> & Pick<FooterProps, 'subscriberCount'> & { npmTag: StorybookNpmTag };
 
 export interface AppLayoutProps {
   children: React.ReactNode;
@@ -32,13 +33,13 @@ const Footer = styled(MarketingFooter)`
 
 export const AppLayout: React.FC<AppLayoutProps> = ({
   children,
-  pageProps: { githubStars, latestPost, latestVersion, subscriberCount },
+  pageProps: { githubStars, latestPost, latestVersion, subscriberCount, npmTag },
 }) => (
   <>
     <GlobalStyles />
     <LinksContextProvider value={navLinks}>
       {githubStars && latestPost && latestVersion && (
-        <Header githubStars={githubStars} latestPost={latestPost} latestVersion={latestVersion} pageType="status" />
+        <Header githubStars={githubStars} latestPost={latestPost} latestVersion={latestVersion} pageType="status" npmTag={npmTag} />
       )}
       <Main>{children}</Main>
       {subscriberCount && <Footer subscriberCount={subscriberCount} />}

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -4,6 +4,7 @@ import { styles } from '@storybook/design-system';
 import { styled } from '@storybook/theming';
 
 import { SubNav, SubNavProps } from './SubNav';
+import { StorybookNpmTag } from '~/model/types';
 
 type EyebrowProps = React.ComponentProps<typeof Eyebrow>;
 type NavProps = React.ComponentProps<typeof Nav>;
@@ -17,6 +18,7 @@ export interface HeaderProps {
   };
   latestVersion: NavProps['version'];
   pageType: SubNavProps['pageType'];
+  npmTag: StorybookNpmTag;
 }
 
 const HeaderWrapper = styled.header`
@@ -27,7 +29,7 @@ const HeaderWrapper = styled.header`
   }
 `;
 
-export const Header: React.FC<HeaderProps> = ({ githubStars, inverse, latestPost, latestVersion, pageType }) => {
+export const Header: React.FC<HeaderProps> = ({ githubStars, inverse, latestPost, latestVersion, pageType, npmTag }) => {
   return (
     <HeaderWrapper>
       <Eyebrow githubStarCount={githubStars} label={latestPost.title} link={latestPost.url} inverse={inverse} />
@@ -38,7 +40,7 @@ export const Header: React.FC<HeaderProps> = ({ githubStars, inverse, latestPost
         version={latestVersion}
         activeSection="docs"
       />
-      <SubNav pageType={pageType} />
+      <SubNav pageType={pageType} npmTag={npmTag} />
     </HeaderWrapper>
   );
 };

--- a/components/layout/SubNav.tsx
+++ b/components/layout/SubNav.tsx
@@ -29,7 +29,7 @@ const subNavItems = (pageType: SubNavProps['pageType']) => [
   {
     key: '1',
     label: 'Support table',
-    href: '/status',
+    href: '/',
     LinkWrapper,
     isActive: pageType === PAGE_TYPES.STATUS,
   },
@@ -60,9 +60,9 @@ export const SubNav: React.FC<SubNavProps> = ({ pageType, npmTag }) => {
             {
               label: 'Versions',
               items: [
-                // TODO: uncomment this once SB 7.0 is merged to main in the monorepo, then change url of next from '/' to '/next'
-                // { label: 'latest', link: { url: '/' } },
-                { label: 'next', link: { url: '/' } },
+                // TODO: uncomment this once SB 7.0 is merged to main in the monorepo, then change url of next from '/status' to '/status/next'
+                // { label: 'latest', link: { url: '/status/latest' } },
+                { label: 'next', link: { url: '/status' } },
               ],
             },
           ]}

--- a/components/layout/SubNav.tsx
+++ b/components/layout/SubNav.tsx
@@ -1,6 +1,15 @@
-import { SubNav as MarketingSubNav, SubNavRight, SubNavTabs, SubNavLinkList } from '@storybook/components-marketing';
+import {
+  SubNav as MarketingSubNav,
+  SubNavRight,
+  SubNavTabs,
+  SubNavLinkList,
+  SubNavDivider,
+  SubNavMenus,
+  Menu,
+} from '@storybook/components-marketing';
 
 import LinkWrapper from 'next/link';
+import { StorybookNpmTag } from '~/model/types';
 
 const TOP_LEVEL_PAGE_TYPES = {
   STATUS: 'status',
@@ -13,6 +22,7 @@ export const PAGE_TYPES = {
 
 export interface SubNavProps {
   pageType: typeof PAGE_TYPES[keyof typeof PAGE_TYPES];
+  npmTag: StorybookNpmTag;
 }
 
 const subNavItems = (pageType: SubNavProps['pageType']) => [
@@ -38,10 +48,27 @@ const supportItems = [
   } as const,
 ];
 
-export const SubNav: React.FC<SubNavProps> = ({ pageType }) => {
+export const SubNav: React.FC<SubNavProps> = ({ pageType, npmTag }) => {
   return pageType !== PAGE_TYPES.NOT_FOUND ? (
     <MarketingSubNav>
       <SubNavTabs label="Status page nav" items={subNavItems(pageType)} />
+      <SubNavDivider />
+      <SubNavMenus>
+        <Menu
+          label={npmTag}
+          items={[
+            {
+              label: 'Versions',
+              items: [
+                // TODO: uncomment this once SB 7.0 is merged to main in the monorepo, then change url of next from '/' to '/next'
+                // { label: 'latest', link: { url: '/' } },
+                { label: 'next', link: { url: '/' } },
+              ],
+            },
+          ]}
+          primary
+        ></Menu>
+      </SubNavMenus>
       <SubNavRight>
         <SubNavLinkList label="Get support:" items={supportItems} />
       </SubNavRight>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -94,13 +94,15 @@ export default function StatusPage({ pageProps, templateData }: Props) {
 const MOCK_DATA = {
   pageProps: layoutMocks,
   templateData: templateMocks,
+  npmTag: 'next',
 };
 
 // DO NOT COMMIT THIS AS TRUE
 const USE_MOCKS = false;
 
 export const getStaticProps: GetStaticProps = async ({ params = {} }) => {
-  const { npmTag: storybookNpmTag } = params as { npmTag: StorybookNpmTag };
+  // TODO: change default value from 'next' to 'latest' once SB 7.0 is merged to main in the monorepo
+  const { npmTag: storybookNpmTag = 'next' } = params as { npmTag: StorybookNpmTag };
 
   if (USE_MOCKS) {
     return {
@@ -111,5 +113,5 @@ export const getStaticProps: GetStaticProps = async ({ params = {} }) => {
   const dxData = await getDxData();
 
   const templateData = await fetchCircleCiData({ storybookNpmTag });
-  return { props: { pageProps: dxData, templateData } };
+  return { props: { pageProps: { ...dxData, npmTag: storybookNpmTag }, templateData } };
 };

--- a/stories/components/layout/AppLayout.stories.tsx
+++ b/stories/components/layout/AppLayout.stories.tsx
@@ -3,6 +3,7 @@ import { StoryObj, Meta } from '@storybook/react';
 import { AppLayout } from '~/components/layout/AppLayout';
 
 const pageProps = {
+  npmTag: 'next',
   contributors: [
     {
       avatar: 'https://avatars.githubusercontent.com/u/50838?v=4',

--- a/stories/components/layout/SubNav.stories.tsx
+++ b/stories/components/layout/SubNav.stories.tsx
@@ -19,5 +19,6 @@ type Story = StoryObj<typeof meta>;
 export const Status: Story = {
   args: {
     pageType: PAGE_TYPES.STATUS,
+    npmTag: 'next',
   },
 };

--- a/stories/pages/page.stories.tsx
+++ b/stories/pages/page.stories.tsx
@@ -10,7 +10,10 @@ const meta = {
   title: 'Pages/Status',
   component: StatusPage,
   args: {
-    pageProps: layoutMocks,
+    pageProps: {
+      ...layoutMocks,
+      npmTag: 'next',
+    },
     templateData: templateMocks.map((template) => ({
       ...template,
       results: template.results.map((result) => ({ ...result, date: new Date(result.date) })),


### PR DESCRIPTION
According to design:
<img width="184" alt="image" src="https://user-images.githubusercontent.com/1671563/210777043-46f924da-b144-4959-99dd-10062a134b68.png">

The only available version will be 'next' until we have latest, but the codes is ready for that.
There are a bunch of TODOs with guidance on what todo once we have data from `next` and `main`