### PR TITLE
Hide version picker for now

### DIFF
--- a/components/layout/SubNav.tsx
+++ b/components/layout/SubNav.tsx
@@ -48,27 +48,34 @@ const supportItems = [
   } as const,
 ];
 
+// TODO: remove this flag once SB 7.0 is merged to main in the monorepo
+const showVersionPicker = false;
+
 export const SubNav: React.FC<SubNavProps> = ({ pageType, npmTag }) => {
   return pageType !== PAGE_TYPES.NOT_FOUND ? (
     <MarketingSubNav>
       <SubNavTabs label="Status page nav" items={subNavItems(pageType)} />
-      <SubNavDivider />
-      <SubNavMenus>
-        <Menu
-          label={npmTag}
-          items={[
-            {
-              label: 'Versions',
-              items: [
-                // TODO: uncomment this once SB 7.0 is merged to main in the monorepo, then change url of next from '/status' to '/status/next'
-                // { label: 'latest', link: { url: '/status/latest' } },
-                { label: 'next', link: { url: '/status' } },
-              ],
-            },
-          ]}
-          primary
-        ></Menu>
-      </SubNavMenus>
+      {showVersionPicker && (
+        <>
+          <SubNavDivider />
+          <SubNavMenus>
+            <Menu
+              label={npmTag}
+              items={[
+                {
+                  label: 'Versions',
+                  items: [
+                    // TODO: uncomment this once SB 7.0 is merged to main in the monorepo, then change url of next from '/status' to '/status/next'
+                    // { label: 'latest', link: { url: '/status/latest' } },
+                    { label: 'next', link: { url: '/status' } },
+                  ],
+                },
+              ]}
+              primary
+            ></Menu>
+          </SubNavMenus>
+        </>
+      )}
       <SubNavRight>
         <SubNavLinkList label="Get support:" items={supportItems} />
       </SubNavRight>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -60,8 +60,12 @@ export default function StatusPage({ pageProps, templateData }: Props) {
       <header>
         <Heading>Status page</Heading>
         <p>
-          Welcome to Storybook&apos;s status page! Each status bar represents the daily CI status for a particular framework integration.
-          Click on a bar to see its details and the specific Storybook version that was tested.
+          Welcome to Storybook’s status page! Each status bar represents the daily CI status for a particular framework integration on
+          Storybook’s{' '}
+          <Link href="https://github.com/storybookjs/storybook/tree/next" target="_blank">
+            next
+          </Link>{' '}
+          branch. Click on a bar to see its details and the specific Storybook version that was tested.
         </p>
       </header>
       <div style={{ display: 'flex', position: 'relative' }}>


### PR DESCRIPTION
Given that we don't have `latest` yet, so we should hide the version picker as it only has one option for now.