### PR TITLE
Ignore internal sandboxes

### DIFF
--- a/services/test-results.ts
+++ b/services/test-results.ts
@@ -180,7 +180,7 @@ function getFeature(jobName: string, className: string) {
 function getAllTemplatesNames(pipeline: EnrichedPipeline) {
   const buildJob = pipeline.jobs.find((it) => it.name === 'build-sandboxes');
   if (buildJob == null) return;
-  return buildJob.tests.map((test) => test.name.split(' - ')[1]);
+  return buildJob.tests.map((test) => test.name.split(' - ')[1]).filter((name) => !name.startsWith('internal/'));
 }
 
 function isPipelineCompleted(pipeline: EnrichedPipeline) {


### PR DESCRIPTION
This PR ignores any sandboxes whose key starts with `"internal/"`, as it is described to be doing in the sandbox templates file.

I tested out the change locally, and it seemed to work.